### PR TITLE
Potential fix for code scanning alert no. 3: Replacement of a substring with itself

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -34,8 +34,7 @@ export default defineConfig(({ mode }) => {
         '^/[a-z]{6}$': backend,
         '/admin': {
           target: backend,
-          changeOrigin: true,
-          rewrite: (p) => p.replace(/^\/admin/, '/admin')
+          changeOrigin: true
         }
       }
     }


### PR DESCRIPTION
Potential fix for [https://github.com/cigoria/simpleShare/security/code-scanning/3](https://github.com/cigoria/simpleShare/security/code-scanning/3)

In general, a “replacement of a substring with itself” warning means either the replacement is pointless and should be removed, or there is a typo and the replacement should actually change the string (for example, adding or stripping a prefix). Here, since `p.replace(/^\/admin/, '/admin')` leaves the path unchanged, the cleanest fix without altering functionality is to remove the `rewrite` function so that the proxy simply forwards `/admin` paths as-is.

Concretely, in `client/vite.config.js`, within the `server.proxy['/admin']` block, delete the `rewrite` property. The result will be:

```js
'/admin': {
  target: backend,
  changeOrigin: true
}
```

No new imports or helper methods are needed; we are only simplifying the existing object literal.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
