### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -1,5 +1,8 @@
 name: PR Build and Startup Test
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: release


### PR DESCRIPTION
Potential fix for [https://github.com/cigoria/simpleShare/security/code-scanning/1](https://github.com/cigoria/simpleShare/security/code-scanning/1)

In general, to fix this issue you explicitly specify a `permissions` block in the workflow (either at the top level, applying to all jobs, or within the specific job) that grants only the minimal required scopes. For a simple CI workflow that just checks out the repository and runs build/tests without interacting with issues, PRs, or releases, `contents: read` is usually sufficient.

The single best way to fix this specific workflow without changing its behavior is to add a root-level `permissions` block after the `name:` (or after `on:`) so it applies to the `build-and-test` job. This workflow only reads repository contents (via `actions/checkout`) and does not need to write to the repo or modify issues/PRs, so we can safely restrict `GITHUB_TOKEN` to `contents: read`. No additional methods, imports, or definitions are needed; it is purely a YAML configuration change in `.github/workflows/pr-build-test.yml` around the beginning of the file (lines 1–6).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
